### PR TITLE
feat: enhance error for invalid items

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -391,7 +391,19 @@ const fetchPaginateIterator = <$Body, Item>(
 
         pageItems = getItems<$Body, Item>(pageBody) ?? [];
 
-        items = merge(pages.map((page) => getItems(page)));
+        items = merge(
+          pages.map((page) => {
+            const eachPageItems = getItems<$Body, Item>(page);
+
+            if (!Array.isArray(eachPageItems)) {
+              throw new Error(
+                "`getItems` option applied to a page must yield an array"
+              );
+            }
+
+            return eachPageItems;
+          })
+        );
 
         done = until
           ? await until({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import parseLinkHeader from "parse-link-header";
 
-interface ParamsObject {
+export interface FetchPaginateParamsObject {
   page?: string;
   limit?: boolean | string;
   offset?: boolean | string;
 }
 
-type Params = ParamsObject | boolean;
+export type FetchPaginateParams = FetchPaginateParamsObject | boolean;
 
 export interface FetchPaginateUntilOptions<$Body, Item> {
   page?: $Body;
@@ -26,7 +26,7 @@ export interface FetchPaginateNextOptions<Item> {
   page: number;
   limit?: number;
   offset: number;
-  params?: Params;
+  params?: FetchPaginateParams;
   isFirst: boolean;
 }
 
@@ -89,7 +89,7 @@ export interface FetchPaginateOptions<$Body, Item> {
   next?: FetchPaginateNextFunction<Item>;
   limit?: number;
   offset?: number;
-  params?: Params;
+  params?: FetchPaginateParams;
   page?: number;
   firstOffset?: number;
   firstPage?: number;
@@ -148,7 +148,7 @@ const getNextWithParams = <Item>({
   offset,
   isFirst,
 }: {
-  params?: Params;
+  params?: FetchPaginateParams;
   pageItems: Item[];
   url: string;
   firstPage: number;

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -152,7 +152,7 @@ describe("fetchPaginate", () => {
 
   describe("getFetch", () => {
     it("should work", async () => {
-      const body = '{"foo":1}';
+      const body = '{"list":[{"foo":1}]}';
       const customFetch = jest.fn(async () => new Response(body));
       const getFetch = jest.fn(() => customFetch);
       const url = "http://api.example.com/one";
@@ -169,7 +169,7 @@ describe("fetchPaginate", () => {
           offset: 0,
           page: 1,
           pageItems: [],
-          pages: [{ foo: 1 }],
+          pages: [{ list: [{ foo: 1 }] }],
           responses: [expect.anything()],
           url,
         },
@@ -179,7 +179,7 @@ describe("fetchPaginate", () => {
     });
 
     it("should resolve async", async () => {
-      const body = '{"foo":1}';
+      const body = '{"list":[{"foo":1}]}';
       const customFetch = jest.fn(async () => new Response(body));
       const getFetch = jest.fn(async () => customFetch);
       const url = "http://api.example.com/one";


### PR DESCRIPTION
Errors before were not clear.

```
TypeError : undefined is not a function
  at Array reduce
```

Now it's better:
```
 Error: `getItems` option applied to a page must yield an array
```
