### PR TITLE
docs: remove extraneous badges from site

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,11 +1,3 @@
-[![npm](https://img.shields.io/npm/v/fetch-paginate.svg)](https://www.npmjs.com/package/fetch-paginate)
-
-[![npm install fetch-paginate (copy)](https://copyhaste.com/i?t=npm%20install%20fetch-paginate)](https://copyhaste.com/c?t=npm%20install%20fetch-paginate "npm install fetch-paginate (copy)")
-
-or:
-
-[![yarn add fetch-paginate (copy)](https://copyhaste.com/i?t=yarn%20add%20fetch-paginate)](https://copyhaste.com/c?t=yarn%20add%20fetch-paginate "yarn add fetch-paginate (copy)")
-
 Fetches multiple pages from paginated APIs with `fetch`
 (using either `Link` headers like GitHub,
 or with `page` or `offset` & `limit` query parameters).


### PR DESCRIPTION
Now that we updated the theme (https://github.com/AndersDJohnson/fetch-paginate/pull/53), we don't need these extra badges.