### PR TITLE
test: fetch options

### DIFF
--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -46,6 +46,23 @@ describe("fetchPaginate", () => {
     expect(responses[0]).toMatchObject({ ok: true });
   });
 
+  it("should forward fetch options", async () => {
+    const fetchOptions = { headers: { Test: "Yes" } };
+    const { items } = await fetchPaginateWrapper("http://api.example.com/headers", {
+      fetchOptions
+    });
+    expect(items).toEqual(["one"]);
+  })
+
+  it("should fail to match forwarded fetch options", async () => {
+    const fetchOptions = { headers: { Test: "Nope" } };
+    expect(fetchPaginateWrapper("http://api.example.com/headers", {
+      fetchOptions
+    })).rejects.toMatchObject({
+      message: expect.stringMatching(/No match for request/),
+    })
+  });
+
   describe("Link header", () => {
     it("should return responses when paginated", async () => {
       const { responses } = await fetchPaginateWrapper(linkedUrl);

--- a/src/test/nocks.ts
+++ b/src/test/nocks.ts
@@ -4,6 +4,12 @@ export const base = "http://api.example.com";
 
 nock(base).get("/one").times(Infinity).reply(200, '{ "list": ["one"] }');
 
+nock(base, {
+  reqheaders: {
+    Test: 'Yes',
+  },
+}).get("/headers").times(Infinity).reply(200, '{ "list": ["one"] }');
+
 nock(base)
   .get("/linked")
   .times(Infinity)


### PR DESCRIPTION
Proves fetch options work in Node via a Jest test. Relates to #70.